### PR TITLE
Restore requested for setDispatcher call in onResume.

### DIFF
--- a/flow/src/main/java/flow/InternalLifecycleIntegration.java
+++ b/flow/src/main/java/flow/InternalLifecycleIntegration.java
@@ -148,7 +148,7 @@ public final class InternalLifecycleIntegration extends Fragment {
   @Override public void onResume() {
     super.onResume();
     if (!dispatcherSet) {
-      flow.setDispatcher(dispatcher);
+      flow.setDispatcher(dispatcher, true);
       dispatcherSet = true;
     }
   }


### PR DESCRIPTION
Should be a fix for https://github.com/square/flow/issues/189 and related issues since currently node.uses counter incremented each time onResume is called.
